### PR TITLE
test(telemetry): align endpoint expectation with eu ingest

### DIFF
--- a/src/tests/telemetry.test.ts
+++ b/src/tests/telemetry.test.ts
@@ -6,7 +6,7 @@ import {
   _setTokenForTesting,
 } from '../utils/telemetry';
 
-const MIXPANEL_ENDPOINT = 'https://api.mixpanel.com/track';
+const MIXPANEL_ENDPOINT = 'https://api-eu.mixpanel.com/track';
 const FAKE_TOKEN = 'test-token-abc123';
 
 const mockFetch = jest.fn().mockResolvedValue({ ok: true });


### PR DESCRIPTION
## Summary
- Align telemetry test expectations with the runtime Mixpanel EU ingest endpoint.
- Fix CI `build-and-test` failures caused by stale URL assertions in `telemetry.test.ts`.
- Keep runtime behavior unchanged; this is a test-only correction.

## Roadmap
Not related to any current roadmap item. (`OVERVIEW.md` with a roadmap section is not present in this repository.)

## Semantic Release
- Commit type: `test`
- Expected version bump: **none**

## Checklist
- [x] Lint passes
- [x] Format passes
- [x] Typecheck passes
- [x] Build succeeds
- [x] Tests pass


Made with [Cursor](https://cursor.com)